### PR TITLE
Change URL's layers separator for QCL filters support

### DIFF
--- a/js/sviewer.js
+++ b/js/sviewer.js
@@ -1133,7 +1133,7 @@ ol.extent.getTopRight(extent).reverse().join(" "),
             config.layersQueryString = qs.layers;
             var ns_layer_style_list = [];
             // parser to retrieve serialized namespace:name[*style[*cql_filter]] and store the description in config
-            ns_layer_style_list = (typeof qs.layers === 'string') ? qs.layers.split(',') : qs.layers;
+            ns_layer_style_list = (typeof qs.layers === 'string') ? qs.layers.split(';') : qs.layers;
             $.each(ns_layer_style_list, function() {
                 config.layersQueryable.push(new LayerQueryable(this));
             });


### PR DESCRIPTION
Actually "layers" parameter use coma as separator for differents layers.

So the coma used by some QCL comparators (like IN) are trucated and don't work.

A solution is to use ";" instead "," to separate layers.