### PR TITLE
Add "qcl_filters" param support [Cleaner way]

### DIFF
--- a/js/sviewer.js
+++ b/js/sviewer.js
@@ -1138,6 +1138,20 @@ ol.extent.getTopRight(extent).reverse().join(" "),
                 config.layersQueryable.push(new LayerQueryable(this));
             });
         }
+        
+        // querystring param: qcl_filters
+        if (qs.qcl_filters) {
+		    var qcl_filters_list = [];
+		    qcl_filters_list = (typeof qs.qcl_filters === 'string') ? qs.qcl_filters.split(';') : qs.qcl_filters;
+			
+		    $.each(qcl_filters_list, function(index) {
+			    if( index < config.layersQueryable.length ) {
+			        var opt = config.layersQueryable[index].options;
+			        opt.cql_filter = this;
+			        config.layersQueryable[index] = new LayerQueryable(opt);
+			    }
+		    });
+        }
 
         // querystring param: xyz
         if (qs.x&&qs.y&&qs.z) {

--- a/js/sviewer.js
+++ b/js/sviewer.js
@@ -1141,16 +1141,16 @@ ol.extent.getTopRight(extent).reverse().join(" "),
         
         // querystring param: qcl_filters
         if (qs.qcl_filters) {
-		    var qcl_filters_list = [];
-		    qcl_filters_list = (typeof qs.qcl_filters === 'string') ? qs.qcl_filters.split(';') : qs.qcl_filters;
+	    var qcl_filters_list = [];
+	    qcl_filters_list = (typeof qs.qcl_filters === 'string') ? qs.qcl_filters.split(';') : qs.qcl_filters;
 			
-		    $.each(qcl_filters_list, function(index) {
-			    if( index < config.layersQueryable.length ) {
-			        var opt = config.layersQueryable[index].options;
-			        opt.cql_filter = this;
-			        config.layersQueryable[index] = new LayerQueryable(opt);
-			    }
-		    });
+	    $.each(qcl_filters_list, function(index) {
+	        if( index < config.layersQueryable.length ) {
+	            var opt = config.layersQueryable[index].options;
+		    opt.cql_filter = this;
+		    config.layersQueryable[index] = new LayerQueryable(opt);
+		}
+	    });
         }
 
         // querystring param: xyz


### PR DESCRIPTION
Instead of change the "layers" param layer separator to support more complex QCL filters because of productions considerations,

I add the support of the "qcl_filters" param wich if provided will override the layers one.

If you want to define complex QCL filters for multiple layers just separate them with ";" in the same order as the layers.

This way we preserve the possibility to include simple filters in the "layers" param.

In this patch, I use the LayerQueryable's constructor to update the TileWMS's QCL filters like fphg suggested.